### PR TITLE
Fix Running from dev/run_app not working in macOS

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -8,7 +8,7 @@
 #' @import rintrojs shinyBS flexdashboard formattable
 #' @noRd
 
-future::plan(future::multiprocess)
+future::plan(future::sequential())
 
 app_ui <- function(request) {
   dashboardPage(


### PR DESCRIPTION
Fix #11 

**Problem**
When we try to run the app from dev/run_app, it will give an error ``` Error in makeClusterPSOCK(workers, ...) : Cluster setup failed. 8 of 8 workers failed to connect.```

The potential reason is with creating a multiprocess cluster in macOS latest version.
The same issue is discussed here https://github.com/rstudio/rstudio/issues/6692

The potential solution is to make our process sequential instead of multiprocess (multiprocess is now deprecated in future)

**Solution**
Use sequential plan instead of multiprocess